### PR TITLE
bug fix:BigArrayImpl.removeBeforeIndex() is checking the timestamp, it

### DIFF
--- a/src/main/java/com/leansoft/bigqueue/BigArrayImpl.java
+++ b/src/main/java/com/leansoft/bigqueue/BigArrayImpl.java
@@ -192,31 +192,28 @@ public class BigArrayImpl implements IBigArray {
 	
 	@Override
 	public void removeBeforeIndex(long index) throws IOException {
-		try {
-			arrayWriteLock.lock();
-			
-			validateIndex(index);
-			
-			long indexPageIndex = Calculator.div(index, INDEX_ITEMS_PER_PAGE_BITS);
-			
-			ByteBuffer indexItemBuffer = this.getIndexItemBuffer(index);
-			long dataPageIndex = indexItemBuffer.getLong();
-			
-			long toRemoveIndexPageTimestamp = this.indexPageFactory.getPageFileLastModifiedTime(indexPageIndex);
-			long toRemoveDataPageItemstamp = this.dataPageFactory.getPageFileLastModifiedTime(dataPageIndex);
-			
-			if (toRemoveIndexPageTimestamp > 0L) { 
-				this.indexPageFactory.deletePagesBefore(toRemoveIndexPageTimestamp);
-			}
-			if (toRemoveDataPageItemstamp > 0L) {
-				this.dataPageFactory.deletePagesBefore(toRemoveDataPageItemstamp);
-			}
-			
-			// advance the tail to index
-			this.arrayTailIndex.set(index);
-		} finally {
-			arrayWriteLock.unlock();
-		}
+    try {
+      arrayWriteLock.lock();
+
+      validateIndex(index);
+
+      long indexPageIndex = Calculator.div(index, INDEX_ITEMS_PER_PAGE_BITS);
+
+      ByteBuffer indexItemBuffer = this.getIndexItemBuffer(index);
+      long dataPageIndex = indexItemBuffer.getLong();
+
+      if (indexPageIndex > 0L) {
+          this.indexPageFactory.deletePagesBeforePageIndex(indexPageIndex);
+      }
+      if (dataPageIndex > 0L) {
+          this.dataPageFactory.deletePagesBeforePageIndex(dataPageIndex);
+      }
+
+      // advance the tail to index
+      this.arrayTailIndex.set(index);
+    } finally {
+      arrayWriteLock.unlock();
+    }
 	}
 	
 

--- a/src/main/java/com/leansoft/bigqueue/page/IMappedPageFactory.java
+++ b/src/main/java/com/leansoft/bigqueue/page/IMappedPageFactory.java
@@ -94,7 +94,15 @@ public interface IMappedPageFactory {
 	 * @throws IOException exception thrown if there was any IO error during the delete operation.
 	 */
 	void deletePagesBefore(long timestamp) throws IOException;
-	
+
+    /**
+     * Delete all pages before the specific index
+     *
+     * @param pageIndex page file index to check
+     * @throws IOException exception thrown if there was any IO error during the delete operation.
+     */
+    void deletePagesBeforePageIndex(long pageIndex) throws IOException;
+
 	/**
 	 * Get last modified timestamp of page file index
 	 * 

--- a/src/main/java/com/leansoft/bigqueue/page/MappedPageFactoryImpl.java
+++ b/src/main/java/com/leansoft/bigqueue/page/MappedPageFactoryImpl.java
@@ -232,7 +232,18 @@ public class MappedPageFactoryImpl implements IMappedPageFactory {
 		}
 	}
 
-	@Override
+    @Override
+    public void deletePagesBeforePageIndex(long pageIndex) throws IOException {
+        Set<Long> indexSet = this.getExistingBackFileIndexSet();
+        for (Long index : indexSet) {
+            if (index < pageIndex) {
+                this.deletePage(index);
+            }
+        }
+    }
+
+
+    @Override
 	public Set<Long> getExistingBackFileIndexSet() {
 		Set<Long> indexSet = new HashSet<Long>();
 		File[] pageFiles = this.pageDirFile.listFiles();

--- a/src/test/java/com/leansoft/bigqueue/TestUtil.java
+++ b/src/test/java/com/leansoft/bigqueue/TestUtil.java
@@ -23,5 +23,5 @@ public class TestUtil {
 		}
 	}
 	
-	public static final String TEST_BASE_DIR = "d:/bigq_test/";
+	public static final String TEST_BASE_DIR = System.getProperty("java.io.tmpdir") + "/bigq_test/";
 }


### PR DESCRIPTION
bug fix:BigArrayImpl.removeBeforeIndex() is checking the timestamp, it might cause data corruption!