### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A big, fast and persistent queue based on memory mapped file.
 
 ***Notice***, bigqueue is just a standalone library, for a high-throughput, persistent, distributed, publish-subscrible messaging system, please refer to [Luxun](https://github.com/bulldog2011/luxun), Luxun messaging system uses bigqueue internally as fast and persistent queue. 
 
-##Feature Highlight:  
+## Feature Highlight:  
 1. **Fast**: close to the speed of direct memory access, both enqueue and dequeue are close to O(1) memory access.  
 2. **Big**: the total size of the queue is only limited by the available disk space.  
 3. **Persistent**: all data in the queue is persisted on disk, and is crash resistant.
@@ -18,12 +18,12 @@ A big, fast and persistent queue based on memory mapped file.
 
 ## The Big Picture
 
-###Memory Mapped Sliding Window
+### Memory Mapped Sliding Window
 
 ![design](http://bulldog2011.github.com/images/luxun/sliding_window.png)
 
 
-##Performance Highlight:
+## Performance Highlight:
 * In concurrent producing and consuming case, the average throughput is around ***166M bytes per second***.
 * In sequential producing then consuming case, the average throughput is around ***333M bytes per second***.
 
@@ -32,7 +32,7 @@ Suppose the average message size is 1KB, then big queue can concurrently produci
 
 [here is a detailed performance report](https://github.com/bulldog2011/bigqueue/wiki/Performance-Test-Report)
 
-##How to Use
+## How to Use
 1. Direct jar or source reference  
 Download jar from repository mentioned in version history section below, latest stable release is [0.7.0](https://github.com/bulldog2011/bulldog-repo/tree/master/repo/releases/com/leansoft/bigqueue/0.7.0).   
 ***Note*** : bigqueue depends on log4j, please also added log4j jar reference if you use bigqueue.
@@ -51,7 +51,7 @@ Download jar from repository mentioned in version history section below, latest 
 		</repository>
 
 
-##Docs
+## Docs
 
 1. [a simple design doc](http://bulldog2011.github.com/blog/2013/01/23/big-queue-design/)
 2. [big queue tutorial](http://bulldog2011.github.com/blog/2013/01/24/big-queue-tutorial/)
@@ -74,7 +74,7 @@ Download jar from repository mentioned in version history section below, latest 
   * Initial version:)
 
 
-##Copyright and License
+## Copyright and License
 Copyright 2012 Leansoft Technology <51startup@sina.com>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License in the LICENSE file, or at:

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -3,7 +3,7 @@ bigqueue
 
 A big, fast and persistent queue based on memory mapped file.
 
-###Feature Highlight:  
+### Feature Highlight:  
 1. **Fast**: close to the speed of direct memory access, both enqueue and dequeue are close to O(1) memory access.  
 2. **Big**: the total size of the queue is only limited by the available disk space.  
 3. **Persistent**: all data in the queue is persisted on disk, and is crash resistant.  
@@ -11,7 +11,7 @@ A big, fast and persistent queue based on memory mapped file.
 5. **Thread-safe**: multiple threads can concurrently enqueue and dequeue without data corruption.  
 6. **Simple&Light-weight**: current number of source files is 12 and the library jar is less than 30K.
 
-###Performance Highlight:
+### Performance Highlight:
 * In concurrent producing and consuming case, the average throughput is around ***166M bytes per second***.
 * In sequential producing then consuming case, the average throughput is around ***333M bytes per second***.
 
@@ -20,7 +20,7 @@ Suppose the average message size is 1KB, then big queue can concurrently produci
 
 [here is a detailed performance report](https://github.com/bulldog2011/bigqueue/wiki/Performance-Test-Report)
 
-###How to Use
+### How to Use
 1. Direct jar reference  
 Download latest [0.6.1 release](https://github.com/bulldog2011/bulldog-repo/tree/master/repo/releases/com/leansoft/bigqueue/0.6.1)
 
@@ -38,7 +38,7 @@ Download latest [0.6.1 release](https://github.com/bulldog2011/bulldog-repo/tree
 		</repository>
 
 
-###Docs
+### Docs
 
 1. [a simple design doc](http://bulldog2011.github.com/blog/2013/01/23/big-queue-design/)
 2. [big queue tutorial](http://bulldog2011.github.com/blog/2013/01/24/big-queue-tutorial/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
